### PR TITLE
Do not duplicate version for versioned branch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,11 @@ else
     BRANCH=`(git rev-parse --abbrev-ref HEAD 2>/dev/null) | grep -v "^master$" || true`;
 fi
 
+# If branch equals version, do not duplicate!
+if [ "${BRANCH}" = "${VERSION}" ]; then
+    unset BRANCH
+fi
+
 if [ -n "${BRANCH}" ]; then
     BRANCH=-${BRANCH};
 fi


### PR DESCRIPTION
When version and branch name are the same, do not duplicate that info.