### PR TITLE
Add optional modsecurity

### DIFF
--- a/options/modsecurity/Dockerfile
+++ b/options/modsecurity/Dockerfile
@@ -1,0 +1,47 @@
+ARG FROM
+FROM $FROM
+
+USER root
+
+RUN true \
+#
+# Update package list
+#
+    && apt-get update \
+#
+# Install modsecurity2
+#
+    && apt-get install -y --no-install-recommends libapache2-mod-security2 unzip \
+    && a2enmod security2 \
+    && cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf \
+#
+# Clean-up
+#
+    && rm -rf /var/lib/apt/lists/*
+
+RUN true \
+#
+# Download and unpack OWASP ModSecurity Core Rule Set (CRS)
+#
+    && cd /tmp \
+    && curl -L https://github.com/coreruleset/coreruleset/archive/refs/tags/v3.3.4.zip --output /tmp/v3.3.4.zip \
+    && unzip /tmp/v3.3.4.zip \
+#
+# Copy OWASP ModSecurity Core Rule Set (CRS)
+#
+    && cp /tmp/coreruleset-3.3.4/crs-setup.conf.example /etc/modsecurity/crs-setup.conf \
+    && mv /tmp/coreruleset-3.3.4/rules/ /etc/modsecurity/ \
+#
+# Remove new config incompatible with Ubuntu distro modsecurity2
+#
+    && rm /etc/modsecurity/rules/REQUEST-922-MULTIPART-ATTACK.conf \
+#
+# Clean-up
+#
+    && rm -rf /tmp/*
+
+# Enable/use OWASP ModSecurity Core Rule Set (CRS)
+COPY options/modsecurity/security2.conf /etc/apache2/mods-enabled/
+
+#
+USER ${APACHE_RUN_USER}

--- a/options/modsecurity/security2.conf
+++ b/options/modsecurity/security2.conf
@@ -1,0 +1,13 @@
+<IfModule security2_module>
+        # Default Debian dir for modsecurity's persistent data
+        SecDataDir /var/cache/modsecurity
+
+        # Include all the *.conf files in /etc/modsecurity.
+        # Keeping your local configuration in that directory
+        # will allow for an easy upgrade of THIS file and
+        # make your life easier
+        IncludeOptional /etc/modsecurity/*.conf
+
+        # Include OWASP ModSecurity CRS rules if installed
+	IncludeOptional /etc/modsecurity/rules/*.conf
+</IfModule>


### PR DESCRIPTION
## Release Notes

- Add optional images with ModSecurity (https://github.com/SpiderLabs/ModSecurity) and OWASP ModSecurity Core Rule Set (CRS) (https://github.com/coreruleset/coreruleset)
  - Fix to version 3.3.4 of coreruleset for now